### PR TITLE
fix(file): Add missing include for basename

### DIFF
--- a/file.c
+++ b/file.c
@@ -12,6 +12,7 @@
 #include <libgen.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <libgen.h>
 
 #include "eco.h"
 


### PR DESCRIPTION
Musl libc 1.2.5 removed the definition of the basename() function from string.h and only provides it in libgen.h as the POSIX standard defines it.

This change fixes compilation with musl libc 1.2.5.
````
build_dir/target-mips_24kc_musl/lua-eco-3.3.0/log/log.c: In function '___log':
build_dir/target-mips_24kc_musl/lua-eco-3.3.0/log/log.c:76:24: error: implicit declaration of function 'basename' [-Werror=implicit-function-declaration]
   76 |             filename = basename(filename);
      |                        ^~~~~~~~
build_dir/target-mips_24kc_musl/lua-eco-3.3.0/log/log.c:76:22: error: assignment to 'const char *' from 'int' makes pointer from integer without a cast [-Werror=int-conversion]
   76 |             filename = basename(filename);
      |                      ^
````